### PR TITLE
fix: compiling errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = { version = "1.6", features = ["v4", "serde"] }
 colored = "2.0"
-winreg = "0.52"
 sysinfo = "0.30"
 rand = "0.8"
 chrono = "0.4"
 is_elevated = "0.1.2" # For checking admin privileges
 directories = "5.0" # For APPDATA, LOCALAPPDATA paths
+[target.'cfg(windows)'.dependencies]
+winreg = "0.52"

--- a/reset_machine.rs
+++ b/reset_machine.rs
@@ -9,7 +9,7 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use sysinfo::{ProcessExt, System, SystemExt};
+use sysinfo::{System};
 use uuid::Uuid;
 use winreg::enums::*;
 use winreg::RegKey;
@@ -47,7 +47,7 @@ fn get_backup_dir_path() -> Option<PathBuf> {
 }
 
 fn get_cursor_package_path() -> Option<PathBuf> {
-    if let Some(user_dirs) = UserDirs::new() {
+    if let Some(user_dirs) = BaseDirs::new() {
         let local_app_data_dir = user_dirs.data_local_dir();
         let primary_path = local_app_data_dir.join("Programs").join("cursor").join("resources").join("app").join("package.json");
         if primary_path.exists() {
@@ -62,7 +62,7 @@ fn get_cursor_package_path() -> Option<PathBuf> {
 }
 
 fn get_cursor_updater_path() -> Option<PathBuf> {
-    if let Some(user_dirs) = UserDirs::new() {
+    if let Some(user_dirs) = BaseDirs::new() {
         let local_app_data_dir = user_dirs.data_local_dir();
         Some(local_app_data_dir.join("cursor-updater"))
     } else {
@@ -188,7 +188,7 @@ fn main() {
     let prefix_hex = "auth0|user_".as_bytes().iter().map(|b| format!("{:02x}", b)).collect::<String>();
     let random_part = get_random_hex(32);
     let machine_id = format!("{}{}", prefix_hex, random_part);
-    let sqm_id = format!("{{}}", Uuid::new_v4().to_string().to_uppercase());
+    let sqm_id = format!("{{{}}}", Uuid::new_v4().to_string().to_uppercase());
 
     // println!("Generated MAC_MACHINE_ID: {}", mac_machine_id);
     // println!("Generated UUID_STR: {}", uuid_str);


### PR DESCRIPTION
**编译环境:**

Windows 11

```powershell
PS > rustc -V
rustc 1.87.0 (17067e9ac 2025-05-09)

PS > cargo -V
cargo 1.87.0 (99624be96 2025-05-06)
```

依赖版本与 [Cargo.toml](https://github.com/agentcodee/cursor-free-everyday/blob/main/Cargo.toml) 保持一致

**解决编译中出现的以下错误：**

```
error: argument never used
   --> src\main.rs:191:34
    |
191 |     let sqm_id = format!("{{}}", Uuid::new_v4().to_string().to_uppercase());
    |                          ------  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ argument never used     
    |                          |
    |                          formatting specifier missing

error[E0432]: unresolved imports `sysinfo::ProcessExt`, `sysinfo::SystemExt`
  --> src\main.rs:12:15
   |
12 | use sysinfo::{ProcessExt, System, SystemExt};
   |               ^^^^^^^^^^          ^^^^^^^^^ no `SystemExt` in the root
   |               |
   |               no `ProcessExt` in the root

error[E0599]: no method named `data_local_dir` found for struct `UserDirs` in the current scope
  --> src\main.rs:51:44
   |
51 |         let local_app_data_dir = user_dirs.data_local_dir();
   |                                            ^^^^^^^^^^^^^^ method not found in `UserDirs`

error[E0599]: no method named `data_local_dir` found for struct `UserDirs` in the current scope
  --> src\main.rs:66:44
   |
66 |         let local_app_data_dir = user_dirs.data_local_dir();
   |                                            ^^^^^^^^^^^^^^ method not found in `UserDirs`
```

**另外，release 中发布的程序的源码是否公开？**